### PR TITLE
feat: add sharepoint site config validation

### DIFF
--- a/deprovision-user.ps1
+++ b/deprovision-user.ps1
@@ -52,6 +52,15 @@ $script:multiple_users = $false
 $script:user_list
 $sharepoint_site = "https://YOURSITE.sharepoint.com/"
 
+#-------------------------------------------------------[Configuration Check]------------------------------------------------------
+
+# Check if $sharepoint_site has been updated
+if ($sharepoint_site -like "*YOURSITE.sharepoint.com*") {
+    Write-Error "Error: Please update the `$sharepoint_site` variable in the script with your actual SharePoint site URL."
+    Write-Host "Example: `$sharepoint_site = 'https://yourcompany.sharepoint.com/'`" -ForegroundColor Yellow
+    Exit 1
+}
+
 #----------------------------------------------------------[Declarations]----------------------------------------------------------
 
 #Script Version

--- a/deprovision-user.ps1
+++ b/deprovision-user.ps1
@@ -13,11 +13,11 @@
     Purpose/Change: Initial script development
     Mod 5/7/25: Updated QOL, comments, function for connecting, module check/install
     Mod 5/14/25: Added function for main components, added abillity to take a CSV
-  
+
 .EXAMPLE
     .\deprovision-user.ps1 -user trevor.cooper -manager tuan.pham -date "10/10/24"
     .\deprovision-user.ps1
-  
+
 .LINK
 #>
 
@@ -34,7 +34,7 @@ param(
 $ProgressPreference = "SilentlyContinue"
 
 #Assemblies
-[System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms") 
+[System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms")
 
 #Script Variables
 $dependency_modules = @(
@@ -45,21 +45,12 @@ $dependency_modules = @(
     "ExchangeOnlineManagement",
     "AzureAD"
 )
-$script:id 
-$script:managerid 
-$script:ooom 
+$script:id
+$script:managerid
+$script:ooom
 $script:multiple_users = $false
 $script:user_list
 $sharepoint_site = "https://YOURSITE.sharepoint.com/"
-
-#-------------------------------------------------------[Configuration Check]------------------------------------------------------
-
-# Check if $sharepoint_site has been updated
-if ($sharepoint_site -like "*YOURSITE.sharepoint.com*") {
-    Write-Error "Error: Please update the `$sharepoint_site` variable in the script with your actual SharePoint site URL."
-    Write-Host "Example: `$sharepoint_site = 'https://yourcompany.sharepoint.com/'`" -ForegroundColor Yellow
-    Exit 1
-}
 
 #----------------------------------------------------------[Declarations]----------------------------------------------------------
 
@@ -73,6 +64,23 @@ if ($sharepoint_site -like "*YOURSITE.sharepoint.com*") {
 Start-Transcript -Force -IncludeInvocationHeader -Path $script:log_file
 
 #-----------------------------------------------------------[Functions]------------------------------------------------------------
+
+function Test-SharePointSiteVariable {
+    <#
+    .SYNOPSIS
+        Checks if the SharePoint site variable has been updated.
+
+    .DESCRIPTION
+        This function verifies if the $sharepoint_site variable still contains the placeholder value.
+        If it does, it outputs an error message and exits the script.
+    #>
+    if ($script:sharepoint_site -like "*YOURSITE.sharepoint.com*") {
+        Write-Error "Error: Please update the `$sharepoint_site` variable in the script with your actual SharePoint site URL."
+        Write-Host "Example: `$sharepoint_site = 'https://yourcompany.sharepoint.com/'`" -ForegroundColor Yellow
+        Exit 1
+    }
+}
+
 function connect_services {
     Write-Host "Due to MFA, we cannot store credentials. So you will be profusely asked for them while connecting to the different platforms." -ForegroundColor Yellow
     Connect-Graph -Scopes User.ReadWrite.All, Organization.Read.All
@@ -94,7 +102,7 @@ function mod_check($mod) {
     if (!(Get-Module -ListAvailable -Name $mod)) {
         Write-Host "$mod is missing, instaling now..."
         Install-Module $mod
-    } 
+    }
     else {
         Write-Host "$mod is installed."
     }
@@ -138,8 +146,8 @@ function remove_groups {
     }
 }
 function remove_licenses {
-    $licenses = Get-MgUserLicenseDetail -UserId $script:id.EmailAddress 
-    $licenses_filtered = @() 
+    $licenses = Get-MgUserLicenseDetail -UserId $script:id.EmailAddress
+    $licenses_filtered = @()
     foreach($license in $licenses) {
         $licenses_filtered += $license.SkuId
     }
@@ -205,6 +213,9 @@ catch {
     exit 1
 }
 
+# Check if $sharepoint_site has been updated
+Test-SharePointSiteVariable
+
 connect_services
 arg_check
 
@@ -221,14 +232,14 @@ if ($multiple_users) {
     foreach ($emp in $script:user_list) {
         Write-Host "Deprovisioning" $emp.user
         initialize_vars -user $emp.user -manager $emp.manager -date $emp.date
-        deprovision_ad 
+        deprovision_ad
         deprovision_msol
     }
 } else {
     Write-Host "Running for a single user"
     initialize_vars -user $user -manager $manager -date $date
     deprovision_ad
-    deprovision_msol 
+    deprovision_msol
 }
 
 Write-Host "Disconnecting from services"


### PR DESCRIPTION
## Description

This pull request introduces a crucial check to ensure that the `$sharepoint_site` variable in the deprovisioning script has been updated by the user. Previously, if this variable was left at its default placeholder value, the script would attempt to connect to an invalid SharePoint site, potentially leading to connection errors or unexpected behavior later in the execution.

This change enhances the script's robustness and user-friendliness by providing an immediate, clear error message if the variable is not configured, preventing further execution with incorrect settings.

## Related Issues / Context

This change addresses a potential point of failure for new users or those running the script without carefully reviewing the configuration variables. It improves the initial setup experience and reduces debugging time related to misconfigured SharePoint connections.

## Changes Made

* Added a conditional check at the script's initialization to verify the `$sharepoint_site` variable.
* If `$sharepoint_site` still contains the placeholder "YOURSITE.sharepoint.com", an error message is displayed.
* The script exits with an error code (1) if the configuration check fails.

## How to Test

1.  Open the `deprovision-user.ps1` script.
2.  **Scenario 1: Unconfigured variable**
    * Ensure the line `$sharepoint_site = "https://YOURSITE.sharepoint.com/"` remains unchanged (or reset it to this value).
    * Run the script from PowerShell (e.g., `.\deprovision-user.ps1`).
    * Verify that an error message similar to "Error: Please update the `$sharepoint_site` variable..." is displayed, and the script terminates immediately.
3.  **Scenario 2: Configured variable**
    * Update the `$sharepoint_site` variable to a valid, non-placeholder SharePoint URL (e.g., `$sharepoint_site = "https://yourcompany.sharepoint.com/"`).
    * Run the script again.
    * Verify that the script proceeds past the initial configuration check without error (it might then prompt for credentials as it attempts to connect to services).

## Checklist

* [x] My code follows the project's coding style conventions.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated any necessary documentation (N/A for this change).
* [ ] I have added tests that prove my fix is effective or that my feature works (manual testing steps provided).
* [ ] New and existing unit tests pass locally with my changes (N/A for this type of script change).